### PR TITLE
Fixes "Not all ff/fi ligatures are resolved"

### DIFF
--- a/spelling-stage-2.lua
+++ b/spelling-stage-2.lua
@@ -46,6 +46,7 @@ local tabremove = table.remove
 local node_new = node.new
 local node_insert_after = node.insert_after
 local node_insert_before = node.insert_before
+local node_traverse = node.traverse
 
 local recurse_node_list = recurse.recurse_node_list
 
@@ -528,14 +529,13 @@ local function __visit_node(head, n)
     handle_glyph(head, n)
   -- Test for discretionary node
   elseif (nid == DISC) then
-    if n.pre ~= nil then
-      if n.pre.char ~= 45 and n.pre.char ~= nil then
-        -- all glyphs besides "-" need to be added
-        handle_glyph(head, n.pre)
+    -- The replace list holds the glyphs as they appear when the
+    -- discretionary is not broken, i.e. the actual word content.  No
+    -- need to combine the pre- and post-break lists.
+    for r in node_traverse(n.replace) do
+      if r.id == GLYPH then
+        handle_glyph(head, r)
       end
-    end
-    if n.post ~= nil and n.post.char ~= nil then
-      handle_glyph(head, n.post)
     end
   -- Test for kerning info
   elseif (nid == KERN) then

--- a/spelling-stage-2.lua
+++ b/spelling-stage-2.lua
@@ -529,12 +529,12 @@ local function __visit_node(head, n)
   -- Test for discretionary node
   elseif (nid == DISC) then
     if n.pre ~= nil then
-      if (n.pre.char ~= 45) then
+      if n.pre.char ~= 45 and n.pre.char ~= nil then
         -- all glyphs besides "-" need to be added
         handle_glyph(head, n.pre)
       end
     end
-    if n.post ~= nil then
+    if n.post ~= nil and n.post.char ~= nil then
       handle_glyph(head, n.post)
     end
   -- Test for kerning info

--- a/spelling-stage-2.lua
+++ b/spelling-stage-2.lua
@@ -493,18 +493,9 @@ local function __vlist_post_recurse()
   end
 end
 
-
---- Find paragraphs and strings.
--- While scanning a node list, this call-back function finds nodes
--- representing the start of a paragraph (local_par whatsit nodes) and
--- strings (chains of nodes of type glyph, kern, disc).
---
--- @param head  Head node of current branch.
--- @param n  The current node.
-local function __visit_node(head, n)
-  local nid = n.id
-  -- Test for word string component node.
-  if nid == GLYPH then
+--- Glyph handling
+-- Adds the given glyph to the current word
+local function handle_glyph(head, n)
     -- Save first node belonging to current word and its head for later
     -- reference.
     if not __curr_word_start then
@@ -521,8 +512,33 @@ local function __visit_node(head, n)
     end
     -- Append character to current word string.
     tabinsert(__curr_word, __codepoint_map[n.char])
-  -- Test for other word string component nodes.
-  elseif (nid == DISC) or (nid == KERN) then
+end
+
+--- Find paragraphs and strings.
+-- While scanning a node list, this call-back function finds nodes
+-- representing the start of a paragraph (local_par whatsit nodes) and
+-- strings (chains of nodes of type glyph, kern, disc).
+--
+-- @param head  Head node of current branch.
+-- @param n  The current node.
+local function __visit_node(head, n)
+  local nid = n.id
+  -- Test for word string component node.
+  if nid == GLYPH then
+    handle_glyph(head, n)
+  -- Test for discretionary node
+  elseif (nid == DISC) then
+    if n.pre ~= nil then
+      if (n.pre.char ~= 45) then
+        -- all glyphs besides "-" need to be added
+        handle_glyph(head, n.pre)
+      end
+    end
+    if n.post ~= nil then
+      handle_glyph(head, n.post)
+    end
+  -- Test for kerning info
+  elseif (nid == KERN) then
     -- We're still within the current word string.  Do nothing.
   -- Test for paragraph start.
   elseif (nid == WHATSIT) and (n.subtype == LOCAL_PAR) then


### PR DESCRIPTION
This fixes https://github.com/sh2d/spelling/issues/16

The issue was the `DISC` nodes were not properly handled. They are inserted as intermediate node and contain the "original" node as pre or post child.